### PR TITLE
chore: remove versioning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,10 +29,6 @@ EOF
     index_document = "index.html"
     error_document = "error.html"
   }
-
-  versioning {
-    enabled = true
-  }
 }
 
 # calculate the hash of the configuration dir


### PR DESCRIPTION
Removes versioning so we can easily empty the bucket. Otherwise we'll need a custom script to delete the storage which seems like a nice-to-have at this point.